### PR TITLE
fixing picker index iOS 7

### DIFF
--- a/src/ios/PickerView.m
+++ b/src/ios/PickerView.m
@@ -318,8 +318,18 @@
 	DLog(@"didDismissWithButtonIndex:%d", buttonIndex);
 
 	// Retreive pickerView
-    NSArray *subviews = [self.actionSheet subviews];
-	UIPickerView *pickerView = [subviews objectAtIndex:1];
+  NSArray *subviews = [self.actionSheet subviews];
+
+  int pickerPosition;
+
+  if (systemMajorVersion == 7){
+   //Order changed in ios?
+   pickerPosition = 2;
+  }else{
+    pickerPosition = 1;
+  }
+
+  UIPickerView *pickerView = [subviews objectAtIndex:pickerPosition];
 	[self sendResultsFromPickerView:pickerView withButtonIndex:buttonIndex];
 }
 

--- a/src/ios/PickerView.m
+++ b/src/ios/PickerView.m
@@ -323,8 +323,7 @@
   int pickerPosition;
 
   if (systemMajorVersion == 7){
-   //Order changed in ios?
-   pickerPosition = 2;
+    pickerPosition = 2;
   }else{
     pickerPosition = 1;
   }


### PR DESCRIPTION
This has been tested for my use-case, only:
- iPhone, iOS <= 7
- a picker with a single "slot"

That said, based on the change, it should hold up pretty well.

fixes #6
